### PR TITLE
Add uv support for sample ci validation

### DIFF
--- a/AI-and-Analytics/Features-and-Functionality/IntelPyTorch_TrainingOptimizations_AMX_BF16/sample.json
+++ b/AI-and-Analytics/Features-and-Functionality/IntelPyTorch_TrainingOptimizations_AMX_BF16/sample.json
@@ -15,11 +15,16 @@
           "steps": [
               "source /intel/oneapi/intelpython/bin/activate",
               "conda activate pytorch",
-              "python -m pip install -r requirements.txt",
-              "python -m ipykernel install --user --name=pytorch",
-              "python pytorch_training_avx512_bf16.py",
-              "python pytorch_training_amx_bf16.py",
-              "jupyter nbconvert --ExecutePreprocessor.enabled=True --ExecutePreprocessor.kernel_name=pytorch --to notebook IntelPyTorch_TrainingOptimizations_AMX_BF16.ipynb"
+              "pip install uv",
+              "uv init",
+              "uv python pin $(which python)",
+              "uv venv --system-site-packages",
+              "uv add -r requirements.txt",
+              "uv add --dev ipykernel notebook",
+              "uv run ipython kernel install --user --name pytorch",
+              "uv run python pytorch_training_avx512_bf16.py",
+              "uv run python pytorch_training_amx_bf16.py",
+              "uv run jupyter nbconvert --ExecutePreprocessor.enabled=True --ExecutePreprocessor.kernel_name=pytorch --to notebook IntelPyTorch_TrainingOptimizations_AMX_BF16.ipynb"
            ]
       }
        ]

--- a/AI-and-Analytics/Features-and-Functionality/IntelTensorFlow_AMX_BF16_Inference/sample.json
+++ b/AI-and-Analytics/Features-and-Functionality/IntelTensorFlow_AMX_BF16_Inference/sample.json
@@ -15,11 +15,16 @@
           "steps": [
               "source /intel/oneapi/intelpython/bin/activate",
               "conda activate tensorflow",
-              "pip install -r requirements.txt --no-deps",
-              "pip install ipykernel jupyter",
-              "python Intel_TensorFlow_AMX_BF16_Inference.py",
-              "python -m ipykernel install --user --name=tensorflow",
-              "jupyter nbconvert --ExecutePreprocessor.enabled=True --ExecutePreprocessor.kernel_name=tensorflow --to notebook IntelTensorFlow_AMX_BF16_Inference.ipynb"
+              "pip install uv",
+              "uv init",
+              "uv python pin $(which python)",
+              "uv venv --system-site-packages",
+              "uv add -r requirements.txt",
+              "uv add numpy==1.26.4",
+              "uv add ipykernel jupyter notebook",
+              "uv run python Intel_TensorFlow_AMX_BF16_Inference.py",
+              "uv run python -m ipykernel install --user --name=tensorflow",
+              "uv run jupyter nbconvert --ExecutePreprocessor.enabled=True --ExecutePreprocessor.kernel_name=tensorflow2 --to notebook IntelTensorFlow_AMX_BF16_Inference.ipynb"
            ]
       }
        ]

--- a/AI-and-Analytics/Features-and-Functionality/IntelTensorFlow_AMX_BF16_Training/IntelTensorFlow_AMX_BF16_Training.ipynb
+++ b/AI-and-Analytics/Features-and-Functionality/IntelTensorFlow_AMX_BF16_Training/IntelTensorFlow_AMX_BF16_Training.ipynb
@@ -59,7 +59,10 @@
     "is_tune_model = True # or False\n",
     "log_dir = \"logs\"\n",
     "profiling_needed = False\n",
+    "execution_mode_param = os.getenv('execution_mode')\n",
     "execution_mode = \"graph\"\n",
+    "if execution_mode_param == \"eager\":\n",
+    "    execution_mode = \"eager\"\n",
     "load_weights_dir = \"weights\"\n",
     "save_weights_dir = \"weights\""
    ]

--- a/AI-and-Analytics/Features-and-Functionality/IntelTensorFlow_AMX_BF16_Training/sample.json
+++ b/AI-and-Analytics/Features-and-Functionality/IntelTensorFlow_AMX_BF16_Training/sample.json
@@ -14,11 +14,18 @@
       "steps": [
         "source /intel/oneapi/intelpython/bin/activate",
         "conda activate tensorflow",
-        "pip install -r requirements.txt",
-        "pip install jupyter ipykernel",
-        "python Intel_TensorFlow_AMX_BF16_Training.py",
-        "python -m ipykernel install --user --name=tensorflow",
-        "jupyter nbconvert --ExecutePreprocessor.enabled=True --ExecutePreprocessor.kernel_name=tensorflow --to notebook IntelTensorFlow_AMX_BF16_Training.ipynb"
+        "pip install uv",
+        "uv init",
+        "uv python pin $(which python)",
+        "uv venv --system-site-packages",
+        "uv add -r requirements.txt",
+        "uv add --dev ipykernel notebook",
+        "uv add numpy==1.26.4",
+        "uv add keras==2.15.0",
+        "export execution_mode=eager",
+        "uv run python Intel_TensorFlow_AMX_BF16_Training.py -m eager",
+        "uv run ipython kernel install --user --name tensorflow",
+        "uv run jupyter nbconvert --ExecutePreprocessor.enabled=True --ExecutePreprocessor.kernel_name=tensorflow --to notebook IntelTensorFlow_AMX_BF16_Training.ipynb"
       ]
     }]
   },

--- a/AI-and-Analytics/Features-and-Functionality/IntelTransformers_Quantization/requirements.txt
+++ b/AI-and-Analytics/Features-and-Functionality/IntelTransformers_Quantization/requirements.txt
@@ -1,7 +1,7 @@
-accelerate==0.29.3
-datasets==2.09.0
-intel-extension-for-transformers==1.4.1
-neural_speed==1.0
-peft==0.10.0
+accelerate
+datasets
+intel-extension-for-transformers
+neural_speed
+peft
 sentencepiece
-transformers==4.38.0
+transformers

--- a/AI-and-Analytics/Features-and-Functionality/IntelTransformers_Quantization/sample.json
+++ b/AI-and-Analytics/Features-and-Functionality/IntelTransformers_Quantization/sample.json
@@ -14,11 +14,17 @@
 			"env": [
 				"source /intel/oneapi/intelpython/bin/activate",
 				"conda activate pytorch",
-				"pip install -r requirements.txt"
+				"pip install uv",
+				"uv init",
+				"uv python pin $(which python)",
+				"uv venv --system-site-packages",
+				"uv add -r requirements.txt",
+				"uv add neural-compressor==2.6",
+				"uv add torch==2.5.0 torchvision==0.20.0"
             ],
 			"id": "itrex_quantize_transformer_models",
 			"steps": [
-				"python quantize_transformer_models_with_itrex.py --model_name \"Intel/neural-chat-7b-v3-1\" --quantize \"int4\" --max_new_tokens 50"
+				"uv run python quantize_transformer_models_with_itrex.py --model_name Intel/neural-chat-7b-v3-1 --quantize int4 --max_new_tokens 50"
 			]
 		}]
 	},

--- a/AI-and-Analytics/Getting-Started-Samples/INC-Quantization-Sample-for-PyTorch/sample.json
+++ b/AI-and-Analytics/Getting-Started-Samples/INC-Quantization-Sample-for-PyTorch/sample.json
@@ -13,13 +13,17 @@
           "env": ["apt-get update && apt-get install -y libgl1 libgl1-mesa-glx libglib2.0-0 libsm6 libxrender1 libxext6",
             "source /intel/oneapi/intelpython/bin/activate",
             "conda activate pytorch",
-            "pip install -r requirements.txt",
-            "pip install ipykernel jupyter",
-            "python -m ipykernel install --user --name=pytorch"
+            "pip install uv",
+            "uv init",
+            "uv add --dev ipykernel notebook",
+            "uv python pin $(which python)",
+            "uv venv --system-site-packages",
+            "uv add -r requirements.txt",
+            "uv run ipython kernel install --user --name pytorch"
           ],
           "id": "quantize with inc",
           "steps": [
-              "jupyter nbconvert --ExecutePreprocessor.enabled=True --ExecutePreprocessor.kernel_name=pytorch --to notebook quantize_with_inc.ipynb"
+              "uv run jupyter nbconvert --ExecutePreprocessor.enabled=True --ExecutePreprocessor.kernel_name=pytorch --to notebook quantize_with_inc.ipynb"
            ]
       }
        ]

--- a/AI-and-Analytics/Getting-Started-Samples/IntelPython_daal4py_GettingStarted/sample.json
+++ b/AI-and-Analytics/Getting-Started-Samples/IntelPython_daal4py_GettingStarted/sample.json
@@ -15,11 +15,16 @@
 			"env": [
 				"source /intel/oneapi/intelpython/bin/activate",
 				"conda activate base",
-				"pip install -r requirements.txt"
+				"pip install uv",
+				"uv init",
+				"uv python pin $(which python)",
+				"uv venv --system-site-packages",
+				"uv add -r requirements.txt",
+				"uv add numpy==1.26.4"
 			],
 			"id": "idp_d4p_GS_py",
 			"steps": [
-				"python IntelPython_daal4py_GettingStarted.py"
+				"uv run python IntelPython_daal4py_GettingStarted.py"
 			]
 		}]
 	},


### PR DESCRIPTION
Use uv tool for isolate cicd env, including 6 samples in `AI-and-Analytics`:

```
1. Getting-Started-Samples/IntelPython_daal4py_GettingStarted
2. Getting-Started-Samples/INC-Quantization-Sample-for-PyTorch
3. Features-and-Functionality/IntelTransformers_Quantization
4. Features-and-Functionality/IntelTensorFlow_AMX_BF16_Training
5. Features-and-Functionality/IntelTensorFlow_AMX_BF16_Inference
6. Features-and-Functionality/IntelPyTorch_TrainingOptimizations_AMX_BF16
```
