### PR TITLE
Use uv tool for isolate cicd env, including samples:

### DIFF
--- a/AI-and-Analytics/Features-and-Functionality/IntelPyTorch_GPU_InferenceOptimization_with_AMP/sample.json
+++ b/AI-and-Analytics/Features-and-Functionality/IntelPyTorch_GPU_InferenceOptimization_with_AMP/sample.json
@@ -14,11 +14,16 @@
         "id": "intel pytorch gpu inference optimization with amp",
         "steps": [
             "source /intel/oneapi/intelpython/bin/activate",
-            "source activate pytorch-gpu",
-            "pip install -r requirements.txt",
-            "pip install jupyter ipykernel",  
-            "python -m ipykernel install --user --name=pytorch-gpu",
-            "python IntelPyTorch_GPU_InferenceOptimization_with_AMP.py"
+            "conda activate pytorch-gpu",
+            "pip install uv notebook",
+            "uv init",
+            "uv python pin $(which python)",
+            "uv venv --system-site-packages",
+            "uv add -r requirements.txt",
+            "uv add numpy==1.26.4",
+            "uv add --dev ipykernel",
+            "uv run ipython kernel install --user --name=pytorch-gpu",
+            "uv run IntelPyTorch_GPU_InferenceOptimization_with_AMP.py"
          ]
     }
      ]

--- a/AI-and-Analytics/Features-and-Functionality/IntelPython_Numpy_Numba_dpnp_kNN/sample.json
+++ b/AI-and-Analytics/Features-and-Functionality/IntelPython_Numpy_Numba_dpnp_kNN/sample.json
@@ -14,13 +14,17 @@
   		"env": [
         "source /intel/oneapi/intelpython/bin/activate",
         "conda activate base", 
-        "pip install numba"
+        "pip install uv",
+        "uv init",
+        "uv python pin $(which python)",
+        "uv venv --system-site-packages",
+        "uv add numba"
       ],
-  		"id": "idp_numpy_numba_dpnp_gs_py",
-  		"steps": [
-         "python IntelPython_Numpy_Numba_dpnp_kNN.py" 
-  		 ]
-  	}
+      "id": "idp_numpy_numba_dpnp_gs_py",
+      "steps": [
+         "uv run python IntelPython_Numpy_Numba_dpnp_kNN.py"
+      ]
+    }
     ]
 },
 "expertise": "Code Optimization"

--- a/AI-and-Analytics/Features-and-Functionality/IntelPython_daal4py_DistributedLinearRegression/sample.json
+++ b/AI-and-Analytics/Features-and-Functionality/IntelPython_daal4py_DistributedLinearRegression/sample.json
@@ -13,13 +13,19 @@
 	"ciTests": {
 		"linux": [{
 			"env": [
-				"source /intel/oneapi/intelpython/bin/activate",
-				"pip install -r requirements.txt"
+                "source /intel/oneapi/intelpython/bin/activate", 
+                "conda activate base", 
+                "pip install uv", 
+                "uv init", 
+                "uv python pin $(which python)", 
+                "uv venv --system-site-packages", 
+                "uv add -r requirements.txt",
+				"uv add numpy==1.26.4" 
 			],
 			"id": "idp_d4p_Linear_Regression_Dist",
 			"steps": [
-				"python download_data.py",
-				"mpirun -n 4 python ./IntelPython_daal4py_Distributed_LinearRegression.py"
+				"uv run python download_data.py",
+				"uv run mpirun -n 4 python ./IntelPython_daal4py_Distributed_LinearRegression.py"
 			]
 		}]
 	},

--- a/AI-and-Analytics/Features-and-Functionality/IntelTensorFlow_TextGeneration_with_LSTM/sample.json
+++ b/AI-and-Analytics/Features-and-Functionality/IntelTensorFlow_TextGeneration_with_LSTM/sample.json
@@ -14,16 +14,19 @@
         {
             "env": [
                 "source /intel/oneapi/intelpython/bin/activate",
-                "conda env remove -n user_tensorflow-gpu",
-                "conda create --name user_tensorflow-gpu --clone tensorflow-gpu",
-                "conda activate user_tensorflow-gpu",
-                "pip install -r requirements.txt",
-                "python -m ipykernel install --user --name=user_tensorflow-gpu"
+                "conda activate tensorflow-gpu",
+                "pip install uv notebook",
+                "uv init",
+                "uv python pin $(which python)",
+                "uv venv --system-site-packages",
+                "uv add -r requirements.txt",
+                "uv add --dev ipykernel",
+                "uv run ipython kernel install --user --name=tensorflow-gpu"
             ],
             "id": "inc_text_generation_lstm_py",
             "steps": [
                 "export ITEX_ENABLE_NEXTPLUGGABLE_DEVICE=0",
-                "ITEX_NUM_EPOCHS=5 KERAS_NUM_EPOCHS=5 python TextGenerationModelTraining.py"
+                "ITEX_NUM_EPOCHS=5 KERAS_NUM_EPOCHS=5 uv run TextGenerationModelTraining.py"
              ]
         }
       ]

--- a/AI-and-Analytics/Getting-Started-Samples/Intel_Extension_For_TensorFlow_GettingStarted/sample.json
+++ b/AI-and-Analytics/Getting-Started-Samples/Intel_Extension_For_TensorFlow_GettingStarted/sample.json
@@ -14,23 +14,36 @@
 		"linux": [{
 			"env": [
 				"source /intel/oneapi/intelpython/bin/activate",
+				"conda activate base",
+				"pip install uv notebook",
+				"uv init",
+				"uv python pin $(which python)",
+				"uv venv --system-site-packages",
+				"uv add -r requirements.txt",
+				"uv add numpy==1.26.4",
+				"uv run ipython kernel install --user --name=tensorflow",
+				"uv run ipython kernel install --user --name=tensorflow-gpu",
+
 				"conda activate tensorflow",
-				"pip install -r requirements.txt --no-deps",
-				"pip install tensorflow==2.15.0.post1",
-				"pip install jupyter ipykernel",
-				"python -m ipykernel install --user --name=tensorflow",
+				"pip install uv notebook",
 				"conda deactivate",
 				"conda activate tensorflow-gpu",
-				"pip install -r requirements.txt --no-deps",
-				"pip install tensorflow==2.15.0.post1",
-				"pip install jupyter ipykernel",
-				"python -m ipykernel install --user --name=tensorflow-gpu",
+				"pip install uv notebook",
 				"conda deactivate"
 			],
 			"id": "itex_sample_test",
 			"steps": [
 				"conda activate tensorflow",
-				"jupyter nbconvert --to notebook --execute ResNet50_Inference.ipynb"
+				"uv python pin $(which python)",
+				"uv venv --system-site-packages",
+				"jupyter nbconvert --ExecutePreprocessor.enabled=True --ExecutePreprocessor.kernel_name=tensorflow --to notebook --execute ResNet50_Inference.ipynb --output ResNet50_Inference.nbcovert.cpu.ipynb",
+				"conda deactivate",
+
+				"conda activate tensorflow-gpu",
+				"uv python pin $(which python)",
+				"uv venv --system-site-packages",
+				"jupyter nbconvert --ExecutePreprocessor.enabled=True --ExecutePreprocessor.kernel_name=tensorflow-gpu --to notebook --execute ResNet50_Inference.ipynb --output ResNet50_Inference.nbcovert.gpu.ipynb",
+				"conda deactivate"
 			]
 		}]
 	},

--- a/AI-and-Analytics/Getting-Started-Samples/Modin_Vs_Pandas/sample.json
+++ b/AI-and-Analytics/Getting-Started-Samples/Modin_Vs_Pandas/sample.json
@@ -14,9 +14,16 @@
 			"id": "modin_pandas_performance",
 			"steps": [
 				"source /intel/oneapi/intelpython/bin/activate",
-				"pip install numpy pandas modin[all]",
-				"pip install jupyter ipykernel",
-				"jupyter nbconvert --ExecutePreprocessor.enabled=True --to notebook Modin_Vs_Pandas.ipynb"
+				"conda activate base",
+				"pip install uv",
+				"uv init",
+				"uv python pin $(which python)",
+				"uv venv --system-site-packages",
+				"uv add numpy pandas modin[all]",
+				"uv add --dev ipykernel",
+				"uv run ipython kernel install --user --name modin_vs_pandas",
+				"uv add notebook",
+				"uv run jupyter nbconvert --ExecutePreprocessor.enabled=True --to notebook Modin_Vs_Pandas.ipynb"
 			]
 		}]
 	},


### PR DESCRIPTION
Use uv tool for isolate cicd env, including 6 samples in `AI-and-Analytics`
```
1.Features-and-Functionality/IntelPython_daal4py_DistributedLinearRegression
2.Features-and-Functionality/IntelPython_Numpy_Numba_dpnp_kNN
3.Features-and-Functionality/IntelPyTorch_GPU_InferenceOptimization_with_AMP
4.Features-and-Functionality/IntelTensorFlow_TextGeneration_with_LSTM
5.Getting-Started-Samples/Intel_Extension_For_TensorFlow_GettingStarted
6.Getting-Started-Samples/Modin_Vs_Pandas
```
